### PR TITLE
Closes #51 - Fix patch tests using migrateable_processmodel_1_0_1_with_formkeys.bpmn

### DIFF
--- a/src/test/resources/test-processmodels/migrateable_processmodel_1_0_1_with_formkeys.bpmn
+++ b/src/test/resources/test-processmodels/migrateable_processmodel_1_0_1_with_formkeys.bpmn
@@ -1,56 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1gkaqyk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1gkaqyk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.1">
   <bpmn:process id="MigrateableProcess" name="Migrateable Process" isExecutable="true" camunda:versionTag="1.0.1" camunda:historyTimeToLive="0">
     <bpmn:startEvent id="StartEvent_1" name="Process started">
       <bpmn:outgoing>SequenceFlow_097y2v3</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="SequenceFlow_097y2v3" sourceRef="StartEvent_1" targetRef="UserTask1" />
-    <bpmn:sequenceFlow id="SequenceFlow_137msd1" sourceRef="UserTask1" targetRef="ReceiveTask1" />
+    <bpmn:sequenceFlow id="SequenceFlow_137msd1" sourceRef="UserTask1" targetRef="UserTask2" />
     <bpmn:endEvent id="EndEvent_0vgdufb" name="Process ended">
       <bpmn:incoming>SequenceFlow_03yewvu</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_03yewvu" sourceRef="ReceiveTask1" targetRef="EndEvent_0vgdufb" />
-    <bpmn:userTask id="UserTask1" name="Do something" camunda:formKey="Formkey1">
+    <bpmn:userTask id="UserTask1" name="Do something (renamed)" camunda:formKey="Formkey1">
       <bpmn:incoming>SequenceFlow_097y2v3</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_137msd1</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:receiveTask id="ReceiveTask1" name="Wait for Message">
-      <bpmn:incoming>SequenceFlow_137msd1</bpmn:incoming>
+    <bpmn:receiveTask id="ReceiveTask1" name="Wait for Message (renamed)">
+      <bpmn:incoming>Flow_0gd2wyi</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_03yewvu</bpmn:outgoing>
     </bpmn:receiveTask>
+    <bpmn:userTask id="UserTask2" name="Do something else (renamed)">
+      <bpmn:incoming>SequenceFlow_137msd1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0gd2wyi</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0gd2wyi" sourceRef="UserTask2" targetRef="ReceiveTask1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MigrateableProcess">
-      <bpmndi:BPMNEdge id="SequenceFlow_03yewvu_di" bpmnElement="SequenceFlow_03yewvu">
-        <di:waypoint x="530" y="117" />
-        <di:waypoint x="592" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_137msd1_di" bpmnElement="SequenceFlow_137msd1">
-        <di:waypoint x="370" y="117" />
-        <di:waypoint x="430" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_097y2v3_di" bpmnElement="SequenceFlow_097y2v3">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="270" y="117" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="159" y="142" width="77" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_0vgdufb_di" bpmnElement="EndEvent_0vgdufb">
-        <dc:Bounds x="592" y="99" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="574" y="142" width="74" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_12twcyc_di" bpmnElement="UserTask1">
         <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0vgdufb_di" bpmnElement="EndEvent_0vgdufb">
+        <dc:Bounds x="722" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="704" y="142" width="74" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0haxaoi_di" bpmnElement="ReceiveTask1">
-        <dc:Bounds x="430" y="77" width="100" height="80" />
+        <dc:Bounds x="560" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1gpdijs_di" bpmnElement="UserTask2">
+        <dc:Bounds x="420" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_097y2v3_di" bpmnElement="SequenceFlow_097y2v3">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_137msd1_di" bpmnElement="SequenceFlow_137msd1">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="420" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_03yewvu_di" bpmnElement="SequenceFlow_03yewvu">
+        <di:waypoint x="660" y="117" />
+        <di:waypoint x="722" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gd2wyi_di" bpmnElement="Flow_0gd2wyi">
+        <di:waypoint x="520" y="117" />
+        <di:waypoint x="560" y="117" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>


### PR DESCRIPTION
Before (Process 1.0.1 is not in patch relation with 1.0.0):
<img width="594" height="346" alt="grafik" src="https://github.com/user-attachments/assets/371ee3d4-e611-49e2-b5f9-b425bbc0af3c" />

After (Process 1.0.1 is in patch relation with 1.0.0, only task names are different):
<img width="760" height="279" alt="Bildschirmfoto 2025-10-24 um 11 39 24" src="https://github.com/user-attachments/assets/ed929a45-4e09-4227-ade3-784265dcb0fd" />