### PR TITLE
use current camunda-mockito library from camunda-community

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,13 +98,13 @@
 		    <version>15.0.0</version>
 		    <scope>test</scope>
 		</dependency>
-	
-		<dependency>
-			<groupId>org.camunda.bpm.extension.mockito</groupId>
-			<artifactId>camunda-bpm-mockito</artifactId>
-			<scope>test</scope>
-			<version>5.16.0</version>
-		</dependency>
+
+        <dependency>
+            <groupId>org.camunda.community.mockito</groupId>
+            <artifactId>camunda-platform-7-mockito</artifactId>
+            <scope>test</scope>
+            <version>${camunda.version}</version>
+        </dependency>
 		
 		<!-- Project Lombok requires IDE extension! -->
 		<dependency>

--- a/src/test/java/de/envite/bpm/camunda/migrator/instances/GetOlderProcessInstancesDefaultImplTest.java
+++ b/src/test/java/de/envite/bpm/camunda/migrator/instances/GetOlderProcessInstancesDefaultImplTest.java
@@ -2,8 +2,8 @@ package de.envite.bpm.camunda.migrator.instances;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.camunda.bpm.extension.mockito.QueryMocks.mockProcessDefinitionQuery;
-import static org.camunda.bpm.extension.mockito.QueryMocks.mockProcessInstanceQuery;
+import static org.camunda.community.mockito.QueryMocks.mockProcessDefinitionQuery;
+import static org.camunda.community.mockito.QueryMocks.mockProcessInstanceQuery;
 import static org.mockito.Mockito.when;
 
 import de.envite.bpm.camunda.migrator.ProcessVersion;


### PR DESCRIPTION
The previously used version was still for Camunda 7.16. This PR bumps it to the one for 7.23.
Be careful though - it might be moved in the future due to the sunset of Camunda 7 CE.