### PR TITLE
Closes #95 - Allow push from GitHub Actions

### DIFF
--- a/.github/workflows/release-after-merge.yml
+++ b/.github/workflows/release-after-merge.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5


### PR DESCRIPTION
This works together with the new Ruleset for protected branches, that allows bypassing with deploy keys.