### PR TITLE
Add Camunda 7.23 parallel build and release

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,8 +25,17 @@ env:
 
 jobs:
   compile:
-    name: Compile all maven modules
+    name: Compile (${{ matrix.camunda_variant }})
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - camunda_variant: default
+            maven_extra_args: ""
+            version_suffix: ""
+          - camunda_variant: camunda-7.23
+            maven_extra_args: "-P camunda-7.23"
+            version_suffix: "-camunda7.23"
     steps:
       - name: Git checkout
         uses: actions/checkout@v6
@@ -40,21 +49,21 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}
+          key: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-${{ matrix.camunda_variant }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-${{ matrix.camunda_variant }}
       - name: Spotless Format Check
         run: mvn spotless:check
       - name: Compile & build
-        run: mvn -B install -DskipTests -Djacoco.skip
+        run: mvn -B install -DskipTests -Djacoco.skip ${{ matrix.maven_extra_args }}
       - name: Populate cache
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          mvn -B dependency:go-offline
-          mvn -B test -Dtest=GibtEsNet -Dsurefire.failIfNoSpecifiedTests=false
+          mvn -B dependency:go-offline ${{ matrix.maven_extra_args }}
+          mvn -B test -Dtest=GibtEsNet -Dsurefire.failIfNoSpecifiedTests=false ${{ matrix.maven_extra_args }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.ARTIFACTS_JARS_NAME }}
+          name: ${{ env.ARTIFACTS_JARS_NAME }}-${{ matrix.camunda_variant }}
           path: ${{ env.ARTIFACTS_JARS_PATH }}
           if-no-files-found: error
       - name: Remove artifacts from cache
@@ -65,8 +74,15 @@ jobs:
 
   test:
     runs-on: ubuntu-22.04
-    name: Test
+    name: Test (${{ matrix.camunda_variant }})
     needs: [ compile ]
+    strategy:
+      matrix:
+        include:
+          - camunda_variant: default
+            maven_extra_args: ""
+          - camunda_variant: camunda-7.23
+            maven_extra_args: "-P camunda-7.23"
     steps:
       - name: Git checkout
         uses: actions/checkout@v6
@@ -79,19 +95,19 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}
+          key: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-${{ matrix.camunda_variant }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-${{ matrix.camunda_variant }}
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
-          name: ${{ env.ARTIFACTS_JARS_NAME }}
+          name: ${{ env.ARTIFACTS_JARS_NAME }}-${{ matrix.camunda_variant }}
           path: ${{ env.ARTIFACTS_JARS_PATH }}
       - name: Test
-        run: mvn -B verify -Dcheckstyle.skip
+        run: mvn -B verify -Dcheckstyle.skip ${{ matrix.maven_extra_args }}
       - name: Upload JaCoCo Report
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.ARTIFACTS_JACOCO_REPORTS_NAME }}
+          name: ${{ env.ARTIFACTS_JACOCO_REPORTS_NAME }}-${{ matrix.camunda_variant }}
           path: ${{ env.ARTIFACTS_JACOCO_REPORTS_PATH }}
           if-no-files-found: ignore
       - name: Cancel workflow
@@ -100,9 +116,18 @@ jobs:
 
   release_artifacts:
     runs-on: ubuntu-22.04
-    name: Release artifacts to Sonatype-Central
+    name: Release artifacts to Sonatype-Central (${{ matrix.camunda_variant }})
     if: github.repository == 'envite-consulting/camunda-process-instance-migrator' && ( startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop' ) && github.head_ref == ''
     needs: [ test ]
+    strategy:
+      matrix:
+        include:
+          - camunda_variant: default
+            maven_extra_args: ""
+            version_suffix: ""
+          - camunda_variant: camunda-7.23
+            maven_extra_args: "-P camunda-7.23"
+            version_suffix: "-camunda7.23"
     # as documented in the gpg manual (https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG_002dAGENT.html)
     # we should execute this command before interacting with gpg (otherwise gpg won't work)
     env:
@@ -119,13 +144,24 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}
+          key: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-${{ matrix.camunda_variant }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-${{ matrix.camunda_variant }}
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
-          name: ${{ env.ARTIFACTS_JARS_NAME }}
+          name: ${{ env.ARTIFACTS_JARS_NAME }}-${{ matrix.camunda_variant }}
           path: ${{ env.ARTIFACTS_JARS_PATH }}
+      - name: Apply version suffix for Camunda variant
+        if: matrix.version_suffix != ''
+        run: |
+          CUR=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:3.5.0:exec)
+          BASE="${CUR%-SNAPSHOT}"
+          if [[ "$GITHUB_REF" =~ ^refs/tags/v ]]; then
+            NEW="${BASE}${{ matrix.version_suffix }}"
+          else
+            NEW="${BASE}${{ matrix.version_suffix }}-SNAPSHOT"
+          fi
+          mvn -B versions:set -DnewVersion="$NEW" -DgenerateBackupPoms=false
       - name: Import GPG Key
         run: echo -n "$GPG_KEY" | base64 --decode | gpg --batch --import
         env:
@@ -133,6 +169,7 @@ jobs:
       - name: Release artifacts to Sonatype-Central
         run: |
           mvn -B deploy -P $([[ "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo "release" || echo "snapshot") \
+          ${{ matrix.maven_extra_args }} \
           --settings ci/mvnsettings.xml -DskipTests -Dcheckstyle.skip -Djacoco.skip
         env:
           GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
@@ -173,8 +210,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}
+          key: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-default-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ env.CACHE_MAVEN_NAME }}-default
       - name: Download JaCoCo reports
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,10 +32,8 @@ jobs:
         include:
           - camunda_variant: default
             maven_extra_args: ""
-            version_suffix: ""
           - camunda_variant: camunda-7.23
             maven_extra_args: "-P camunda-7.23"
-            version_suffix: "-camunda7.23"
     steps:
       - name: Git checkout
         uses: actions/checkout@v6

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,12 @@
 
 	<profiles>
 		<profile>
+      <id>camunda-7.23</id>
+      <properties>
+        <camunda.version>7.23.0</camunda.version>
+      </properties>
+    </profile>
+    <profile>
       <id>snapshot</id>
       <build>
         <plugins>


### PR DESCRIPTION
## Summary
- Adds a Maven profile `camunda-7.23` that overrides `camunda.version` to `7.23.0`
- CI matrix now builds, tests, and releases both the default (7.24) and 7.23 variant in parallel
- The 7.23 artifact is published to Maven Central with a `-camunda7.23` version suffix (e.g. `2.1.0-camunda7.23`), keeping `2.1.0` as the main/default artifact

## How it works
- **Maven profile**: activate with `-P camunda-7.23` to build against 7.23 locally
- **CI matrix**: `compile`, `test`, and `release_artifacts` jobs each run twice — once for each Camunda variant
- **Version suffix**: in the `release_artifacts` job, the 7.23 build sets its version to `{base}-camunda7.23[-SNAPSHOT]` before deploying, so both artifacts coexist on Maven Central under the same `artifactId`
- **Cache isolation**: each variant has its own Maven cache key to prevent dependency conflicts between 7.23 and 7.24

## Test plan
- [ ] Verify CI runs both matrix entries for `compile` and `test`
- [ ] Verify `release_artifacts` publishes both `2.x.x` and `2.x.x-camunda7.23` to Sonatype Central on a tag push
- [ ] Verify local build with `-P camunda-7.23` compiles and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)